### PR TITLE
change email message now that the restrictions are over

### DIFF
--- a/src/admin/match/email/email.ts
+++ b/src/admin/match/email/email.ts
@@ -32,8 +32,7 @@ export async function post(req: Request, res: Response): Promise<void> {
             ],
             subject: "It's a match!",
             body: "Congratulations! You have both been matched together to go and get a #CuriousCoffee."
-                + "During this time of isolation this is an opportunity to meet someone over video."
-                + " Now it's over to you to start the conversation!"
+                + " With the restrictions lifted you can now meet-up in the office, its over to you to start the conversation!"
         };
         const params: Params = {
             email: email


### PR DESCRIPTION
Request from Mel Griffiths to change the emmail tamplate

Currently it states - Congratulations! You have both been matched together to go and get a #CuriousCoffee.During this time of isolation this is an opportunity to meet someone over video. Now it's over to you to start the conversation!


Can it be changed to -

Congratulations!
You have both been matched together to go and get a #CuriousCoffee. With the restrictions lifted you can now meet-up in the office, its over to you to start the conversation!